### PR TITLE
Normalizing multiple times

### DIFF
--- a/URLNormalizer.php
+++ b/URLNormalizer.php
@@ -32,7 +32,7 @@ class URLNormalizer {
     private $fragment;
     private $default_scheme_ports = array( 'http' => 80, 'https' => 443, );
 
-    public function __construct() {
+    public function __construct( $url=null ) {
         $this->scheme   = '';
         $this->host     = '';
         $this->port     = '';
@@ -41,6 +41,10 @@ class URLNormalizer {
         $this->path     = '';
         $this->query    = '';
         $this->fragment = '';
+        
+        if ( $url ) {
+        	$this->setUrl( $url );
+        }
     }
     
     public function getUrl() {

--- a/URLNormalizerTest.php
+++ b/URLNormalizerTest.php
@@ -25,6 +25,11 @@ class URLNormalizerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue( method_exists( $this->fixture, 'getUrl' ) );
     }
     
+    public function testSetUrlFromConstructor() {
+    	$this->fixture = new URLNormalizer( 'http://www.example.com/' );
+    	$this->assertTrue( $this->fixture->getUrl() == 'http://www.example.com/' );
+    }
+    
     public function testSetUrl() {
         $this->assertTrue( $this->fixture->getUrl() == $this->test_url );
     }


### PR DESCRIPTION
When you normalized a url more than once, the url you get back would change each time.  (it would keep adding an extra '://' to the scheme.)

Here's a fix for that, as well as a couple of other conveniences.
