### PR TITLE
fixed a bug caused by querystrings with an array in it

### DIFF
--- a/README
+++ b/README
@@ -24,6 +24,7 @@ http://www.example.com/%7Eusername/ and http://www.example.com/~username/
 http://www.example.com and http://www.example.com/
 http://www.example.com:80/bar.html and http://www.example.com/bar.html
 http://www.example.com/../a/b/../c/./d.html and http://www.example.com/a/c/d.html
+http://www.example.com/?array[key]=value and http://www.example.com/?array%5Bkey%5D=value
 
 The following normalizations are performed:
 

--- a/URLNormalizer.php
+++ b/URLNormalizer.php
@@ -39,6 +39,19 @@ class URLNormalizer {
         }
     }
 
+    private function getQuery($query) {
+        $qs = array();
+        foreach($query as $qk => $qv) {
+            if(is_array($qv)) {
+                $qs[rawurldecode($qk)] = $this->getQuery($qv);
+            }
+            else {
+                $qs[rawurldecode($qk)] = rawurldecode($qv);
+            }
+        }
+        return $qs;
+    }
+
     public function getUrl() {
         return $this->url;
     }
@@ -160,11 +173,9 @@ class URLNormalizer {
         if ( $this->query ) {
             parse_str( $this->query, $query );
 
-            $keys = array_map( 'rawurldecode', array_keys( $query ) );
-            $values = array_map( 'rawurldecode', array_values( $query ) );
-            $query = array_combine( $keys, $values );
-
-            $this->query = '?' . str_replace( '+', '%20', http_build_query( $query, null, '&' ) );
+            //encodes every parameter correctly
+            $qs = $this->getQuery($query);
+            $this->query = '?' . str_replace( '+', '%20', http_build_query( $qs, null, '&' ) );
             
             // Fix http_build_query adding equals sign to empty keys
             $this->query = str_replace( '=&', '&', rtrim( $this->query, '=' ));

--- a/URLNormalizerTest.php
+++ b/URLNormalizerTest.php
@@ -239,4 +239,9 @@ class URLNormalizerTest extends PHPUnit_Framework_TestCase
         $this->fixture->setUrl( "http://www.example.com/!$&'()*+,;=/" );
         $this->assertEquals( "http://www.example.com/!$&'()*+,;=/", $this->fixture->normalize() );
     }
+
+    public function testQueryWithArray() {
+        $this->fixture->setUrl('http://www.example.com/?array[key]=value');
+        $this->assertEquals('http://www.example.com/?array%5Bkey%5D=value', $this->fixture->normalize() );
+    }
 }

--- a/test-client.php
+++ b/test-client.php
@@ -62,6 +62,8 @@ test('http://example.com/', 'http://example.com/');
 
 test('http://example.com/path/?query=space value', 'http://example.com/path/?query=space%20value');
 
+test('http://www.example.com/?array[key]=value', 'http://www.example.com/?array%5Bkey%5D=value');
+
 /**
  * Test URL Normalization
  *


### PR DESCRIPTION
querystrings are now checked for arrays and handled properly:
e.g. http://www.example.com/?array[key]=value equals http://www.example.com/?array%5Bkey%5D=value
