### PR TITLE
Update Normalizer.php

### DIFF
--- a/src/URL/Normalizer.php
+++ b/src/URL/Normalizer.php
@@ -138,7 +138,7 @@ class Normalizer {
             // @link http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2
 
             // Converting the host to lower case
-            $authority .= strtolower( $this->host );
+            $authority .= mb_strtolower( $this->host, 'UTF-8' );
 
             // Port
             // @link http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.3


### PR DESCRIPTION
Normalizer works incorrectly with non-ASCII domains — this is what is expected:
http://www.Яндекс.РФ → http://www.яндекс.рф
http://dev.ŽiŪrKėNaS.lt → http://dev.žiūrkėnas.lt

Additionally, a requirement for "mb_strtolower" function to be used could be added with a line in "composer.json"

```
"ext-mbstring": "*",
```
