### PR TITLE
Weak type check broke URLs that ended in "#0"

### DIFF
--- a/src/URL/Normalizer.php
+++ b/src/URL/Normalizer.php
@@ -233,7 +233,7 @@ class Normalizer
         // Fragment
         // @link https://tools.ietf.org/html/rfc3986#section-3.5
 
-        if ($this->fragment) {
+        if ($this->fragment !== '') {
             $this->fragment = rawurldecode($this->fragment);
             $this->fragment = rawurlencode($this->fragment);
             $this->fragment = '#' . $this->fragment;


### PR DESCRIPTION
If the fragment entity is exactly string "0", as if the URL http://example.com/#0 is passed to the method the if statment in Line 236 will return false even tough it should not an the returned URL will be http://example.com/0 which is incorrect.